### PR TITLE
(graph): correct iterables, and introduce linked list for trust relat…

### DIFF
--- a/src/graph/Graph.sol
+++ b/src/graph/Graph.sol
@@ -99,6 +99,8 @@ contract Graph is ProxyFactory, IGraph {
      * however, upon untrusting (or edge removal), we need to synchronize
      * the state of the smart contract with other processes,
      * so we want to introduce a predictable time marker for the expiration of trust.
+     * Trust markers additionally store a linked list to iterate through the trusted
+     * entities.
      */
     mapping(address => mapping(address => TrustMarker)) public trustMarkers;
 


### PR DESCRIPTION
…ions

fixes #21 

~~still todo: add view functions for SDK to iterate over the trust relations cleanly~~
trustMarkers is already publicly viewable, so it might be better to build the iterator in the SDK rather than a heavy solidity loop that goes to query all the tokens.