### PR TITLE
(circles): start implementing group circle node

### DIFF
--- a/specifications/TCIP005-group-circles.md
+++ b/specifications/TCIP005-group-circles.md
@@ -1,0 +1,2 @@
+# Native Group Circles
+

--- a/src/circles/GroupCircle.sol
+++ b/src/circles/GroupCircle.sol
@@ -5,74 +5,75 @@ import "./TemporalDiscount.sol";
 import "../proxy/MasterCopyNonUpgradable.sol";
 import "../graph/ICircleNode.sol";
 import "../graph/IGraph.sol";
-
-
-/**
- * Upon minting group tokens, are the underlying circles
- * to be locked for later redemption, or instead burned.
- * Redemption only allows you to recover your personal circles,
- * for however many of your personal circles are available in the group.
- * (todo: this is one redemption strategy, up for later discussion)
- */
-enum MintBehaviour {
-    Lock,
-    Burn
-}
+import "./IGroup.sol";
 
 contract GroupCircle is MasterCopyNonUpgradable, TemporalDiscount, IGroupCircleNode {
-
     // State variables
 
     IGraph public graph;
 
     // todo: we probably want group to have an interface so that we can call hooks on it
-    address public group;
+    IGroup public group;
 
-    MintBehaviour public mintBehaviour;
+    /**
+     * The exit fee (represented as 128bit 64.64 fixed point) is charged upon
+     * unwrapping the group circles back to the collateral personal circles.
+     * Note that one can only unwrap group circles for the amount of personal
+     * circles that are collateralized in the group, ie. the minimum of the amount
+     * of group circles you want to unwrap, and the amount of your personal
+     * circles that are collateralized in this group.
+     * If the the exit fee is set to the maximum of 100% (= 2**64 in 64.64),
+     * then upon minting the collateral is immediately burnt instead.
+     */
+    int128 public exitFee_64x64;
+
+    /**
+     * Burn collateral upon minting is set to true,
+     * if the exit fee was set to 100%.
+     */
+    bool public burnCollateralUponMinting;
 
     // Modifiers
 
     modifier onlyGraphOrGroup() {
         require(
-            msg.sender == address(graph) || msg.sender == group,
-            "Only graph or group can call this function."
+            msg.sender == address(graph) || msg.sender == address(group), "Only graph or group can call this function."
         );
         _;
     }
 
     modifier onlyGraph() {
-        require(
-            msg.sender == address(graph),
-            "Only graph can call this function."
-        );
+        require(msg.sender == address(graph), "Only graph can call this function.");
         _;
     }
 
     // External functions
 
-    function setup(address _group, ) external {
-        require(
-            address(graph) == address(0),
-            "Group circle contract has already been setup."
-        );
+    function setup(address _group, int128 _exitFee_64x64) external {
+        require(address(graph) == address(0), "Group circle contract has already been setup.");
 
-        require(
-            address(_group) != address(0),
-            "Group address must not be zero address"
-        );
-        
+        require(address(_group) != address(0), "Group address must not be zero address");
+
+        require(_exitFee_64x64 <= ONE_64x64, "Exit fee can maximally be 100%.");
+
+        if (_exitFee_64x64 == ONE_64x64) {
+            burnCollateralUponMinting = true;
+        } else {
+            burnCollateralUponMinting = false;
+        }
+
         // graph contract must call setup after deploying proxy contract
         graph = IGraph(msg.sender);
-        group = _group;
+        group = IGroup(_group);
         creationTime = block.timestamp;
+        exitFee_64x64 = _exitFee_64x64;
     }
 
     function entity() external view returns (address entity_) {
-        return entity_ = group;
+        return entity_ = address(group);
     }
 
     function pathTransfer(address _from, address _to, uint256 _amount) external onlyGraph {
-
         // todo: should there be a hook here to call group?
 
         _transfer(_from, _to, _amount);
@@ -83,6 +84,44 @@ contract GroupCircle is MasterCopyNonUpgradable, TemporalDiscount, IGroupCircleN
         return active_ = true;
     }
 
-    // function mint();
+    function mint(ICircleNode[] calldata _collateral, uint256[] calldata _amount) external {
+        require(_collateral.length == _amount.length, "Collateral and amount arrays must have equal length.");
 
+        require(_collateral.length > 0, "At least one collateral must be provided.");
+
+        // note: this is for code readability, this gets compiled out.
+        // To compose group tokens as deposited collateral must be burnt.
+        // For example, if collateral is preserved one could redeposit
+        // (the same) group tokens, and the collateral would accumulate on
+        // what should be an idempotent function call.
+        // This prevents games to be played with inflated total collateral held by groups.
+        bool acceptGroupTokensAsCollateral = burnCollateralUponMinting;
+
+        require(
+            graph.checkAllAreValidCircleNodes(_collateral, acceptGroupTokensAsCollateral),
+            "All collateral must be valid circles on this graph."
+        );
+
+        // rely on group logic to evaluate whether minting should proceed
+        group.beforeMintPolicy(msg.sender, _collateral, _amount);
+
+        uint256 totalGroupCirclesToMint = uint256(0);
+
+        for (uint256 i = 0; i < _collateral.length; i++) {
+            _collateral[i].transferFrom(msg.sender, address(this), _amount[i]);
+            totalGroupCirclesToMint += _amount[i];
+        }
+
+        _mint(msg.sender, totalGroupCirclesToMint);
+
+        if (burnCollateralUponMinting) {
+            for (uint256 i = 0; i < _collateral.length; i++) {
+                _collateral[i].burn(_amount[i]);
+            }
+        }
+    }
+
+    function burn(uint256 _amount) external {
+        _burn(msg.sender, _amount);
+    }
 }

--- a/src/circles/GroupCircle.sol
+++ b/src/circles/GroupCircle.sol
@@ -8,21 +8,68 @@ import "../graph/IGraph.sol";
 
 contract GroupCircle is MasterCopyNonUpgradable, TemporalDiscount, IGroupCircleNode {
 
+    // State variables
+
+    IGraph public graph;
+
+    // todo: we probably want group to have an interface so that we can call hooks on it
+    address public group;
+
+
+
+    // Modifiers
+
+    modifier onlyGraphOrGroup() {
+        require(
+            msg.sender == address(graph) || msg.sender == group,
+            "Only graph or group can call this function."
+        );
+        _;
+    }
+
+    modifier onlyGraph() {
+        require(
+            msg.sender == address(graph),
+            "Only graph can call this function."
+        );
+        _;
+    }
+
+    // External functions
+
     function setup(address _group) external {
+        require(
+            address(graph) == address(0),
+            "Group circle contract has already been setup."
+        );
 
+        require(
+            address(_group) != address(0),
+            "Group address must not be zero address"
+        );
+        
+        // graph contract must call setup after deploying proxy contract
+        graph = IGraph(msg.sender);
+        group = _group;
+        creationTime = block.timestamp;
     }
 
-    function entity() external view returns (address) {
-
+    function entity() external view returns (address entity_) {
+        return entity_ = group;
     }
 
-    function pathTransfer(address from, address to, uint256 amount) external {
+    function pathTransfer(address _from, address _to, uint256 _amount) external onlyGraph {
 
+        // todo: should there be a hook here to call group?
+
+        _transfer(_from, _to, _amount);
     }
 
+    // todo: does this mean something for group currencies?
     function isActive() external pure returns (bool active_) {
-
         return active_ = true;
     }
+
+    // function mint();
 
 }

--- a/src/circles/GroupCircle.sol
+++ b/src/circles/GroupCircle.sol
@@ -98,7 +98,7 @@ contract GroupCircle is MasterCopyNonUpgradable, TemporalDiscount, IGroupCircleN
         bool acceptGroupTokensAsCollateral = burnCollateralUponMinting;
 
         require(
-            graph.checkAllAreValidCircleNodes(_collateral, acceptGroupTokensAsCollateral),
+            graph.checkAllAreTrustedCircleNodes(address(group), _collateral, acceptGroupTokensAsCollateral),
             "All collateral must be valid circles on this graph."
         );
 

--- a/src/circles/GroupCircle.sol
+++ b/src/circles/GroupCircle.sol
@@ -97,11 +97,11 @@ contract GroupCircle is MasterCopyNonUpgradable, TemporalDiscount, IGroupCircleN
         require(_collateral.length > 0, "At least one collateral must be provided.");
 
         // note: this is for code readability, this gets compiled out.
-        // To compose group tokens as deposited collateral must be burnt.
+        // To use group tokens as deposited collateral, they must be burnt.
         // For example, if collateral is preserved one could redeposit
         // (the same) group tokens, and the collateral would accumulate on
         // what should be an idempotent function call.
-        // This prevents games to be played with inflated total collateral held by groups.
+        // Burning the collateral prevents games to be played with inflated total collateral held by groups.
         bool acceptGroupTokensAsCollateral = burnCollateralUponMinting;
 
         require(

--- a/src/circles/GroupCircle.sol
+++ b/src/circles/GroupCircle.sol
@@ -6,6 +6,19 @@ import "../proxy/MasterCopyNonUpgradable.sol";
 import "../graph/ICircleNode.sol";
 import "../graph/IGraph.sol";
 
+
+/**
+ * Upon minting group tokens, are the underlying circles
+ * to be locked for later redemption, or instead burned.
+ * Redemption only allows you to recover your personal circles,
+ * for however many of your personal circles are available in the group.
+ * (todo: this is one redemption strategy, up for later discussion)
+ */
+enum MintBehaviour {
+    Lock,
+    Burn
+}
+
 contract GroupCircle is MasterCopyNonUpgradable, TemporalDiscount, IGroupCircleNode {
 
     // State variables
@@ -15,7 +28,7 @@ contract GroupCircle is MasterCopyNonUpgradable, TemporalDiscount, IGroupCircleN
     // todo: we probably want group to have an interface so that we can call hooks on it
     address public group;
 
-
+    MintBehaviour public mintBehaviour;
 
     // Modifiers
 
@@ -37,7 +50,7 @@ contract GroupCircle is MasterCopyNonUpgradable, TemporalDiscount, IGroupCircleN
 
     // External functions
 
-    function setup(address _group) external {
+    function setup(address _group, ) external {
         require(
             address(graph) == address(0),
             "Group circle contract has already been setup."

--- a/src/circles/GroupCircle.sol
+++ b/src/circles/GroupCircle.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity >=0.8.13;
+
+import "./TemporalDiscount.sol";
+import "../proxy/MasterCopyNonUpgradable.sol";
+import "../graph/ICircleNode.sol";
+import "../graph/IGraph.sol";
+
+contract GroupCircle is MasterCopyNonUpgradable, TemporalDiscount, IGroupCircleNode {
+
+    function setup(address _group) external {
+
+    }
+
+    function entity() external view returns (address) {
+
+    }
+
+    function pathTransfer(address from, address to, uint256 amount) external {
+
+    }
+
+    function isActive() external pure returns (bool active_) {
+
+        return active_ = true;
+    }
+
+}

--- a/src/circles/GroupCircle.sol
+++ b/src/circles/GroupCircle.sol
@@ -48,6 +48,11 @@ contract GroupCircle is MasterCopyNonUpgradable, TemporalDiscount, IGroupCircleN
         _;
     }
 
+    constructor() {
+        // block setup on the master copy deployment of the group circle
+        graph = IGraph(address(1));
+    }
+
     // External functions
 
     function setup(address _group, int128 _exitFee_64x64) external {
@@ -56,6 +61,7 @@ contract GroupCircle is MasterCopyNonUpgradable, TemporalDiscount, IGroupCircleN
         require(address(_group) != address(0), "Group address must not be zero address");
 
         require(_exitFee_64x64 <= ONE_64x64, "Exit fee can maximally be 100%.");
+        require(_exitFee_64x64 >= int128(0), "Exit fee can not be negative.");
 
         if (_exitFee_64x64 == ONE_64x64) {
             burnCollateralUponMinting = true;

--- a/src/circles/IGroup.sol
+++ b/src/circles/IGroup.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity >=0.8.13;
+
+import "../graph/ICircleNode.sol";
+
+interface IGroup {
+    // todo: these are sketches of a simple interface
+    // should be considered again
+    function beforeMintPolicy(address minter, ICircleNode[] calldata collateral, uint256[] calldata amount) external;
+}

--- a/src/circles/IGroup.sol
+++ b/src/circles/IGroup.sol
@@ -6,5 +6,7 @@ import "../graph/ICircleNode.sol";
 interface IGroup {
     // todo: these are sketches of a simple interface
     // should be considered again
-    function beforeMintPolicy(address minter, ICircleNode[] calldata collateral, uint256[] calldata amount) external;
+    function beforeMintPolicy(address minter, ICircleNode[] calldata collateral, uint256[] calldata amount)
+        external
+        returns (bool adjust, int128[] calldata adjustmentFactors);
 }

--- a/src/circles/TemporalDiscount.sol
+++ b/src/circles/TemporalDiscount.sol
@@ -199,11 +199,6 @@ contract TemporalDiscount is IERC20 {
         // but the pattern is off if we change the signature to pass currentSpan,
         // todo: evaluate if it is worth splitting the signatures for this...
         uint256 currentSpan = _currentTimeSpan();
-        // [this is wrong!] note: we don't discount the total supply before adding an amount
-        // because we account for discounts in the individual balances
-        // and already subtract those, so we should not double count.
-        // temporalTotalSupply += _amount;
-        // totalSupplyTime = currentSpan;
         _discountTotalSupplyThenMint(_amount, currentSpan);
         _discountBalanceThenAdd(_owner, _amount, currentSpan);
 

--- a/src/circles/TemporalDiscount.sol
+++ b/src/circles/TemporalDiscount.sol
@@ -34,7 +34,7 @@ contract TemporalDiscount is IERC20 {
     /**
      * Store the signed 128-bit 64.64 representation of 1 as a constant
      */
-    int128 private constant ONE_64x64 = int128(18446744073709551616);
+    int128 internal constant ONE_64x64 = int128(18446744073709551616);
 
     /**
      * Reduction factor gamma for temporally discounting balances
@@ -313,8 +313,8 @@ contract TemporalDiscount is IERC20 {
         if (totalSupplyTime == _currentSpan) {
             temporalTotalSupply += _amount;
         } else {
-            uint256 discountedTotalSupply = _calculateDiscountedBalance(
-                temporalTotalSupply, _currentSpan - totalSupplyTime);
+            uint256 discountedTotalSupply =
+                _calculateDiscountedBalance(temporalTotalSupply, _currentSpan - totalSupplyTime);
             temporalTotalSupply = discountedTotalSupply + _amount;
             totalSupplyTime = _currentSpan;
         }
@@ -324,8 +324,8 @@ contract TemporalDiscount is IERC20 {
         if (totalSupplyTime == _currentSpan) {
             temporalTotalSupply -= _amount;
         } else {
-            uint256 discountedTotalSupply = _calculateDiscountedBalance(
-                temporalTotalSupply, _currentSpan - totalSupplyTime);
+            uint256 discountedTotalSupply =
+                _calculateDiscountedBalance(temporalTotalSupply, _currentSpan - totalSupplyTime);
             temporalTotalSupply = discountedTotalSupply - _amount;
             totalSupplyTime = _currentSpan;
         }

--- a/src/circles/TemporalDiscount.sol
+++ b/src/circles/TemporalDiscount.sol
@@ -199,14 +199,21 @@ contract TemporalDiscount is IERC20 {
         // but the pattern is off if we change the signature to pass currentSpan,
         // todo: evaluate if it is worth splitting the signatures for this...
         uint256 currentSpan = _currentTimeSpan();
-        // note: we don't discount the total supply before adding an amount
+        // [this is wrong!] note: we don't discount the total supply before adding an amount
         // because we account for discounts in the individual balances
         // and already subtract those, so we should not double count.
-        temporalTotalSupply += _amount;
-        totalSupplyTime = currentSpan;
+        // temporalTotalSupply += _amount;
+        // totalSupplyTime = currentSpan;
+        _discountTotalSupplyThenMint(_amount, currentSpan);
         _discountBalanceThenAdd(_owner, _amount, currentSpan);
 
         emit Transfer(address(0), _owner, _amount);
+    }
+
+    function _burn(address _owner, uint256 _amount) internal {
+        uint256 currentSpan = _currentTimeSpan();
+        _discountBalanceThenSubtract(msg.sender, _amount, currentSpan);
+        _discountTotalSupplyThenBurn(_amount, currentSpan);
     }
 
     /**
@@ -245,8 +252,8 @@ contract TemporalDiscount is IERC20 {
             // and update the timespan in which we updated the balance.
             balanceTimeSpans[_owner] = _currentSpan;
 
-            // adjust total supply to reflect discount cost
-            _subtractTotalSupply(discountCost_, _currentSpan);
+            // // adjust total supply to reflect discount cost
+            // _subtractTotalSupply(discountCost_, _currentSpan);
 
             // emit DiscountCost only when effectively discounted.
             // if the original balance was zero before adding,
@@ -283,8 +290,8 @@ contract TemporalDiscount is IERC20 {
             // and update the timespan in which we updated the balance.
             balanceTimeSpans[_owner] = _currentSpan;
 
-            // adjust total supply to reflect discount cost
-            _subtractTotalSupply(discountCost_, _currentSpan);
+            // // adjust total supply to reflect discount cost
+            // _subtractTotalSupply(discountCost_, _currentSpan);
 
             // emit DiscountCost only when effectively discounted.
             emit DiscountCost(_owner, discountCost_);
@@ -292,12 +299,34 @@ contract TemporalDiscount is IERC20 {
         }
     }
 
-    function _subtractTotalSupply(uint256 _discountCost, uint256 _currentSpan) private {
-        // note: we don't discount the total supply in write operations,
-        // because we already have accounted for the discounts
-        // in the costs that get subtracted.
-        temporalTotalSupply = temporalTotalSupply - _discountCost;
-        totalSupplyTime = _currentSpan;
+    // function _subtractTotalSupply(uint256 _discountCost, uint256 _currentSpan) private {
+    //     // note: we don't discount the total supply in write operations,
+    //     // because we already have accounted for the discounts
+    //     // in the costs that get subtracted.
+    //     temporalTotalSupply = temporalTotalSupply - _discountCost;
+    //     totalSupplyTime = _currentSpan;
+    // }
+
+    function _discountTotalSupplyThenMint(uint256 _amount, uint256 _currentSpan) private {
+        if (totalSupplyTime == _currentSpan) {
+            temporalTotalSupply += _amount;
+        } else {
+            uint256 discountedTotalSupply = _calculateDiscountedBalance(
+                temporalTotalSupply, _currentSpan - totalSupplyTime);
+            temporalTotalSupply = discountedTotalSupply + _amount;
+            totalSupplyTime = _currentSpan;
+        }
+    }
+
+    function _discountTotalSupplyThenBurn(uint256 _amount, uint256 _currentSpan) private {
+        if (totalSupplyTime == _currentSpan) {
+            temporalTotalSupply -= _amount;
+        } else {
+            uint256 discountedTotalSupply = _calculateDiscountedBalance(
+                temporalTotalSupply, _currentSpan - totalSupplyTime);
+            temporalTotalSupply = discountedTotalSupply - _amount;
+            totalSupplyTime = _currentSpan;
+        }
     }
 
     function _calculateDiscountedBalance(uint256 _balance, uint256 _numberOfTimeSpans)

--- a/src/circles/TemporalDiscount.sol
+++ b/src/circles/TemporalDiscount.sol
@@ -249,13 +249,10 @@ contract TemporalDiscount is IERC20 {
             // and update the timespan in which we updated the balance.
             balanceTimeSpans[_owner] = _currentSpan;
 
-            // // adjust total supply to reflect discount cost
-            // _subtractTotalSupply(discountCost_, _currentSpan);
 
             // emit DiscountCost only when effectively discounted.
             // if the original balance was zero before adding,
             // discount cost can still be zero, even when discounted
-            // todo: possibly optimise? at cost of more if clauses?
             if (discountCost_ != uint256(0)) {
                 emit DiscountCost(_owner, discountCost_);
             }
@@ -287,22 +284,13 @@ contract TemporalDiscount is IERC20 {
             // and update the timespan in which we updated the balance.
             balanceTimeSpans[_owner] = _currentSpan;
 
-            // // adjust total supply to reflect discount cost
-            // _subtractTotalSupply(discountCost_, _currentSpan);
-
             // emit DiscountCost only when effectively discounted.
+            // note: there must have been some discount cost, because we subtracted
+            //     an amount from the balance successfully.
             emit DiscountCost(_owner, discountCost_);
             return discountCost_;
         }
     }
-
-    // function _subtractTotalSupply(uint256 _discountCost, uint256 _currentSpan) private {
-    //     // note: we don't discount the total supply in write operations,
-    //     // because we already have accounted for the discounts
-    //     // in the costs that get subtracted.
-    //     temporalTotalSupply = temporalTotalSupply - _discountCost;
-    //     totalSupplyTime = _currentSpan;
-    // }
 
     function _discountTotalSupplyThenMint(uint256 _amount, uint256 _currentSpan) private {
         if (totalSupplyTime == _currentSpan) {

--- a/src/circles/TemporalDiscount.sol
+++ b/src/circles/TemporalDiscount.sol
@@ -34,7 +34,7 @@ contract TemporalDiscount is IERC20 {
     /**
      * Store the signed 128-bit 64.64 representation of 1 as a constant
      */
-    int128 internal constant ONE_64x64 = int128(18446744073709551616);
+    int128 internal constant ONE_64x64 = int128(2**64);
 
     /**
      * Reduction factor gamma for temporally discounting balances

--- a/src/circles/TemporalDiscount.sol
+++ b/src/circles/TemporalDiscount.sol
@@ -212,8 +212,10 @@ contract TemporalDiscount is IERC20 {
 
     function _burn(address _owner, uint256 _amount) internal {
         uint256 currentSpan = _currentTimeSpan();
-        _discountBalanceThenSubtract(msg.sender, _amount, currentSpan);
+        _discountBalanceThenSubtract(_owner, _amount, currentSpan);
         _discountTotalSupplyThenBurn(_amount, currentSpan);
+
+        emit Transfer(_owner, address(0), _amount);
     }
 
     /**

--- a/src/circles/TimeCircle.sol
+++ b/src/circles/TimeCircle.sol
@@ -169,6 +169,10 @@ contract TimeCircle is MasterCopyNonUpgradable, TemporalDiscount, IAvatarCircleN
         return _calculateIssuance(_currentTimeSpan());
     }
 
+    function burn(uint256 _amount) external {
+        _burn(msg.sender, _amount);
+    }
+
     // Public functions
 
     function isActive() public view returns (bool active_) {

--- a/src/circles/TimeCircle.sol
+++ b/src/circles/TimeCircle.sol
@@ -86,7 +86,7 @@ contract TimeCircle is MasterCopyNonUpgradable, TemporalDiscount, IAvatarCircleN
     }
 
     modifier notStopped() {
-        require(!stopped, "Node can not have been stopped.");
+        require(!stopped, "Node must not have been stopped.");
         _;
     }
 
@@ -107,8 +107,7 @@ contract TimeCircle is MasterCopyNonUpgradable, TemporalDiscount, IAvatarCircleN
         lastIssuanceTimeSpan = _currentTimeSpan();
 
         // instantiate the linked list
-        // todo: this is not necessary with a prepend-linked list?
-        // migrations[SENTINEL_MIGRATION] = SENTINEL_MIGRATION;
+        migrations[SENTINEL_MIGRATION] = SENTINEL_MIGRATION;
 
         // loop over memory array to insert migration history into linked list
         for (uint256 i = 0; i < _migrations.length; i++) {
@@ -230,13 +229,14 @@ contract TimeCircle is MasterCopyNonUpgradable, TemporalDiscount, IAvatarCircleN
     // Private function
 
     function _insertMigration(address _migration) private {
+        assert(_migration != SENTINEL_MIGRATION);
         require(_migration != address(0), "Migration address cannot be zero address.");
         // idempotent under repeated insertion
         if (migrations[_migration] != address(0)) {
             return;
         }
         // prepend new migration address at beginning of linked list
-        migrations[_migration] = SENTINEL_MIGRATION;
+        migrations[_migration] = migrations[SENTINEL_MIGRATION];
         migrations[SENTINEL_MIGRATION] = _migration;
     }
 

--- a/src/circles/TimeCircle.sol
+++ b/src/circles/TimeCircle.sol
@@ -6,7 +6,7 @@ import "../proxy/MasterCopyNonUpgradable.sol";
 import "../graph/ICircleNode.sol";
 import "../graph/IGraph.sol";
 
-contract TimeCircle is MasterCopyNonUpgradable, TemporalDiscount, ICircleNode {
+contract TimeCircle is MasterCopyNonUpgradable, TemporalDiscount, IAvatarCircleNode {
     // Constants
 
     address public constant SENTINEL_MIGRATION = address(0x1);
@@ -124,6 +124,10 @@ contract TimeCircle is MasterCopyNonUpgradable, TemporalDiscount, ICircleNode {
             // and clearer to understand for new users.
             _mint(avatar, TIME_BONUS * EXA);
         }
+    }
+
+    function entity() external view returns (address entity_) {
+        return entity_ = avatar;
     }
 
     function claimIssuance() external onlyActive {

--- a/src/circles/TimeCircle.sol
+++ b/src/circles/TimeCircle.sol
@@ -90,6 +90,11 @@ contract TimeCircle is MasterCopyNonUpgradable, TemporalDiscount, IAvatarCircleN
         _;
     }
 
+    constructor() {
+        // block the mastercopy from getting called setup on
+        graph = IGraph(address(1));
+    }
+
     // External functions
 
     function setup(address _avatar, bool _active, address[] calldata _migrations) external {

--- a/src/graph/ICircleNode.sol
+++ b/src/graph/ICircleNode.sol
@@ -6,18 +6,27 @@ import "../circles/IERC20.sol";
 /// @author CirclesUBI
 /// @title Circle Node interface
 interface ICircleNode is IERC20 {
-    function setup(address avatar, bool active, address[] calldata migrations) external;
 
-    function avatar() external view returns (address);
-
-    function claimIssuance() external;
+    function entity() external view returns (address);
 
     function pathTransfer(address from, address to, uint256 amount) external;
 
+    function isActive() external view returns (bool active);
+}
+
+interface IAvatarCircleNode is ICircleNode {
+
+    function setup(address avatar, bool active, address[] calldata migrations) external;
+
+    // function claimIssuance() external; 
+
     function paused() external view returns (bool paused);
     function stopped() external view returns (bool stopped);
-    function isActive() external view returns (bool active);
 
     function pause() external;
     function unpause() external;
+}
+
+interface IGroupCircleNode is ICircleNode {
+    function setup(address group) external;
 }

--- a/src/graph/ICircleNode.sol
+++ b/src/graph/ICircleNode.sol
@@ -6,19 +6,19 @@ import "../circles/IERC20.sol";
 /// @author CirclesUBI
 /// @title Circle Node interface
 interface ICircleNode is IERC20 {
-
     function entity() external view returns (address);
 
     function pathTransfer(address from, address to, uint256 amount) external;
 
     function isActive() external view returns (bool active);
+
+    function burn(uint256 amount) external;
 }
 
 interface IAvatarCircleNode is ICircleNode {
-
     function setup(address avatar, bool active, address[] calldata migrations) external;
 
-    // function claimIssuance() external; 
+    // function claimIssuance() external;
 
     function paused() external view returns (bool paused);
     function stopped() external view returns (bool stopped);
@@ -28,5 +28,5 @@ interface IAvatarCircleNode is ICircleNode {
 }
 
 interface IGroupCircleNode is ICircleNode {
-    function setup(address group) external;
+    function setup(address group, int128 exitFee_64x64) external;
 }

--- a/src/graph/IGraph.sol
+++ b/src/graph/IGraph.sol
@@ -4,10 +4,15 @@ pragma solidity >=0.8.13;
 import "./ICircleNode.sol";
 
 interface IGraph {
-    function trust(address _avatar) external;
-    function untrust(address _avatar) external;
+    // function trust(address _avatar) external;
+    // function untrust(address _avatar) external;
 
-    function checkAncestorMigrations(address _avatar)
+    function checkAllAreValidCircleNodes(ICircleNode[] calldata circles, bool includeGroups)
         external
-        returns (bool objectToStartMint_, address[] memory migrationTokens_);
+        view
+        returns (bool allValid_);
+
+    // function checkAncestorMigrations(address _avatar)
+    //     external
+    //     returns (bool objectToStartMint_, address[] memory migrationTokens_);
 }

--- a/src/graph/IGraph.sol
+++ b/src/graph/IGraph.sol
@@ -7,10 +7,10 @@ interface IGraph {
     // function trust(address _avatar) external;
     // function untrust(address _avatar) external;
 
-    function checkAllAreValidCircleNodes(ICircleNode[] calldata circles, bool includeGroups)
+    function checkAllAreTrustedCircleNodes(address group, ICircleNode[] calldata circles, bool includeGroups)
         external
         view
-        returns (bool allValid_);
+        returns (bool allTrusted_);
 
     // function checkAncestorMigrations(address _avatar)
     //     external

--- a/src/graph/IGroup.sol
+++ b/src/graph/IGroup.sol
@@ -1,4 +1,0 @@
-// SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity >=0.8.13;
-
-interface IGroup {}

--- a/test/graph/Graph.t.sol
+++ b/test/graph/Graph.t.sol
@@ -6,13 +6,16 @@ import {StdCheats} from "forge-std/StdCheats.sol";
 import "../../src/graph/Graph.sol";
 import "../../src/graph/ICircleNode.sol";
 import "../../src/circles/TimeCircle.sol";
+import "../../src/circles/GroupCircle.sol";
 import "./MockHubV1.sol";
 import "./MockInternalGraph.sol";
 
 contract GraphTest is Test {
     // State variables
 
-    TimeCircle public masterContractTimeCircle;
+    TimeCircle public masterCopyTimeCircle;
+
+    GroupCircle public masterCopyGroupCircle;
 
     MockHubV1 public mockHubV1;
 
@@ -25,13 +28,15 @@ contract GraphTest is Test {
 
     function setUp() public {
         // no need to call setup() on master copy
-        masterContractTimeCircle = new TimeCircle();
+        masterCopyTimeCircle = new TimeCircle();
+
+        masterCopyGroupCircle = new GroupCircle();
 
         mockHubV1 = new MockHubV1();
 
-        graph = new Graph(mockHubV1, masterContractTimeCircle);
+        graph = new Graph(mockHubV1, masterCopyTimeCircle, masterCopyGroupCircle);
 
-        mockInternalGraph = new MockInternalGraph(mockHubV1, masterContractTimeCircle);
+        mockInternalGraph = new MockInternalGraph(mockHubV1, masterCopyTimeCircle, masterCopyGroupCircle);
     }
 
     function testUnpackCoordinates() public {

--- a/test/graph/GraphPathTransfer.t.sol
+++ b/test/graph/GraphPathTransfer.t.sol
@@ -52,8 +52,7 @@ contract GraphPathTransferTest is Test, TimeSetup {
         // all participants should have 48 TIC as signup bonus
         // todo: test this as separate unit test in graph.t.sol
         for (uint256 i = 0; i < N; i++) {
-            assertEq(circleNodes[i].balanceOf(addresses[i]),
-                masterContractTimeCircle.TIME_BONUS() * TIC);
+            assertEq(circleNodes[i].balanceOf(addresses[i]), masterContractTimeCircle.TIME_BONUS() * TIC);
         }
 
         // to build a correct flow matrix, we need to present the vertices
@@ -65,7 +64,6 @@ contract GraphPathTransferTest is Test, TimeSetup {
     }
 
     function testSinglePathTransfer() public {
-
         // Flow matrix for transferring tokens from Alice to David
         //       A    B    C    D
         // A-B  -5    5    -    -
@@ -108,7 +106,7 @@ contract GraphPathTransferTest is Test, TimeSetup {
         graph.singlePathTransfer(
             uint16(permutationMap[0]), // from Alice
             uint16(permutationMap[3]), // to David
-            uint256(5 * TIC),  // send 5 Time Circles
+            uint256(5 * TIC), // send 5 Time Circles
             flowVertices,
             flow,
             packedCoordinates
@@ -122,9 +120,7 @@ contract GraphPathTransferTest is Test, TimeSetup {
      *      and returns the permutation map. This is not meant to be an efficient sort,
      *      rather the simplest implementation for transparancy of the test.
      */
-    function sortAddressesWithPermutationMap() 
-        private 
-    {
+    function sortAddressesWithPermutationMap() private {
         uint256 length = addresses.length;
         sortedAddresses = addresses;
         // permutationMap = new uint[N];
@@ -153,20 +149,16 @@ contract GraphPathTransferTest is Test, TimeSetup {
      * @param _coordinates The array of uint16 coordinates.
      * @return packedData_ The packed coordinates as bytes.
      */
-    function packCoordinates(uint16[] memory _coordinates) 
-        private pure 
-        returns (bytes memory packedData_)
-    {
+    function packCoordinates(uint16[] memory _coordinates) private pure returns (bytes memory packedData_) {
         packedData_ = new bytes(_coordinates.length * 2);
 
-        for (uint i = 0; i < _coordinates.length; i++) {
+        for (uint256 i = 0; i < _coordinates.length; i++) {
             packedData_[2 * i] = bytes1(uint8(_coordinates[i] >> 8)); // High byte
             packedData_[2 * i + 1] = bytes1(uint8(_coordinates[i] & 0xFF)); // Low byte
         }
     }
 
     function makeLinearTrustGraph() private {
-
         // David trust (->) Charlie, C -> B, B -> A
         // so that Alice can send tokens to David over A-B-C-D
         for (uint256 i = N - 1; i > 0; i--) {

--- a/test/graph/GraphPathTransfer.t.sol
+++ b/test/graph/GraphPathTransfer.t.sol
@@ -6,6 +6,7 @@ import {StdCheats} from "forge-std/StdCheats.sol";
 import "../../src/graph/Graph.sol";
 import "../../src/graph/ICircleNode.sol";
 import "../../src/circles/TimeCircle.sol";
+import "../../src/circles/GroupCircle.sol";
 import "../setup/TimeSetup.sol";
 import "./MockHubV1.sol";
 
@@ -19,7 +20,9 @@ contract GraphPathTransferTest is Test, TimeSetup {
 
     // State variables
 
-    TimeCircle public masterContractTimeCircle;
+    TimeCircle public masterCopyTimeCircle;
+
+    GroupCircle public masterCopyGroupCircle;
 
     MockHubV1 public mockHubV1;
 
@@ -34,11 +37,13 @@ contract GraphPathTransferTest is Test, TimeSetup {
 
     function setUp() public {
         // no need to call setup() on master copy
-        masterContractTimeCircle = new TimeCircle();
+        masterCopyTimeCircle = new TimeCircle();
+
+        masterCopyGroupCircle = new GroupCircle();
 
         mockHubV1 = new MockHubV1();
 
-        graph = new Graph(mockHubV1, masterContractTimeCircle);
+        graph = new Graph(mockHubV1, masterCopyTimeCircle, masterCopyGroupCircle);
 
         startTime();
 
@@ -46,13 +51,13 @@ contract GraphPathTransferTest is Test, TimeSetup {
             addresses[i] = makeAddr(avatars[i]);
             vm.prank(addresses[i]);
             graph.registerAvatar();
-            circleNodes[i] = graph.avatarToNode(addresses[i]);
+            circleNodes[i] = graph.avatarToCircle(addresses[i]);
         }
 
         // all participants should have 48 TIC as signup bonus
         // todo: test this as separate unit test in graph.t.sol
         for (uint256 i = 0; i < N; i++) {
-            assertEq(circleNodes[i].balanceOf(addresses[i]), masterContractTimeCircle.TIME_BONUS() * TIC);
+            assertEq(circleNodes[i].balanceOf(addresses[i]), masterCopyTimeCircle.TIME_BONUS() * TIC);
         }
 
         // to build a correct flow matrix, we need to present the vertices

--- a/test/graph/MockInternalGraph.sol
+++ b/test/graph/MockInternalGraph.sol
@@ -6,7 +6,11 @@ import "../../src/graph/ICircleNode.sol";
 import "../../src/migration/IHub.sol";
 
 contract MockInternalGraph is Graph {
-    constructor(IHubV1 _ancestor, ICircleNode _masterCopyCircleNode) Graph(_ancestor, _masterCopyCircleNode) {}
+    constructor(
+        IHubV1 _ancestor,
+        IAvatarCircleNode _masterCopyAvatarCircleNode,
+        IGroupCircleNode _masterCopyGroupCircleNode
+    ) Graph(_ancestor, _masterCopyAvatarCircleNode, _masterCopyGroupCircleNode) {}
 
     // function trust(address _avatar) external override {
     //     notMocked();

--- a/test/setup/TimeSetup.sol
+++ b/test/setup/TimeSetup.sol
@@ -5,7 +5,6 @@ import {Test} from "forge-std/Test.sol";
 import {StdCheats} from "forge-std/StdCheats.sol";
 
 contract TimeSetup is Test {
-
     // must match circles/TemporalDiscount.sol/ZERO_TIME
     uint256 internal constant ZERO_TIME = uint256(1639094400);
 


### PR DESCRIPTION
fixes #23 #29 

- [x] separate the interface for avatar circle nodes, and group circle nodes
- [x] preserve that Circle nodes are path transferable, regardless of being avatar or group
- [x] ~~implement GroupCircle~~ ✅, and add it as a master copy to graph to deploy upon registering group currency
- [x] implement hooks to group contract for additional checks managed by group, and not the trust relations
- [x] improve the interface for the group to inspect or modify the proposed mint https://github.com/CirclesUBI/circles-contracts-v2/commit/0cb93587513ab1ed57724fee1c0498981231b261